### PR TITLE
[url_launcher] Improving unit tests on mac

### DIFF
--- a/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
+++ b/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
@@ -6,7 +6,7 @@ import FlutterMacOS
 import XCTest
 import url_launcher_macos
 
-class StubWorkspace: URLLauncher {
+class StubWorkspace: SystemURLHandler {
   var isSuccessful = true
   var url = URL.init(string: "https://flutter.dev")
 

--- a/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
+++ b/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
@@ -47,9 +47,9 @@ class RunnerTests: XCTestCase {
       call,
       result: { (result: Any?) -> Void in
         XCTAssertNotNil(result)
-        let canLuanch = result! as? Bool
-        XCTAssertNotNil(canLuanch)
-        XCTAssertTrue(canLuanch!)
+        let canLaunch = result! as? Bool
+        XCTAssertNotNil(canLaunch)
+        XCTAssertTrue(canLaunch!)
       })
   }
 
@@ -62,9 +62,9 @@ class RunnerTests: XCTestCase {
       call,
       result: { (result: Any?) -> Void in
         XCTAssertNotNil(result)
-        let canLuanch = result! as? Bool
-        XCTAssertNotNil(canLuanch)
-        XCTAssertFalse(canLuanch!)
+        let canLaunch = result! as? Bool
+        XCTAssertNotNil(canLaunch)
+        XCTAssertFalse(canLaunch!)
       })
   }
 

--- a/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
+++ b/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
@@ -89,9 +89,9 @@ class RunnerTests: XCTestCase {
     pluginWithStubWorkspace.handle(
       call,
       result: { (result: Any?) -> Void in
-          XCTAssertNotNil(result)
-          let launch = result! as? Bool
-          XCTAssertNotNil(launch)
+        XCTAssertNotNil(result)
+        let launch = result! as? Bool
+        XCTAssertNotNil(launch)
       })
   }
 

--- a/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
+++ b/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
@@ -7,38 +7,37 @@ import XCTest
 import url_launcher_macos
 
 class StubWorkspace: SystemURLHandler {
+
   var isSuccessful = true
-  var url = URL.init(string: "https://flutter.dev")
 
   func open(_ url: URL) -> Bool {
     return isSuccessful
   }
 
   func urlForApplication(toOpen: URL) -> URL? {
-    return url
+      return toOpen
   }
-
 }
 
 class RunnerTests: XCTestCase {
 
-  var workspace: StubWorkspace! = nil
-  var pluginWithStubWorkspace: UrlLauncherPlugin! = nil
-  var plugin: UrlLauncherPlugin! = nil
+  func testNoHandlerReturnsFlutterMethodNotImplemented() throws {
+    let plugin = UrlLauncherPlugin()
 
-  override func setUp() {
-    workspace = StubWorkspace()
-    pluginWithStubWorkspace = UrlLauncherPlugin(workspace)
-    plugin = UrlLauncherPlugin()
+    let call = FlutterMethodCall(
+      methodName: "noHandler",
+      arguments: ["url": "https://flutter.dev"])
+
+    plugin.handle(
+      call,
+      result: { (result: Any?) -> Void in
+        XCTAssertEqual(result as? NSObject, FlutterMethodNotImplemented)
+      })
   }
 
-  override func tearDown() {
-    workspace = nil
-    pluginWithStubWorkspace = nil
-    plugin = nil
-  }
+  func testCanLaunchSuccessReturnsTrue() throws {
+    let plugin = UrlLauncherPlugin()
 
-  func testCanLaunchSuccessTrue() throws {
     let call = FlutterMethodCall(
       methodName: "canLaunch",
       arguments: ["url": "https://flutter.dev"])
@@ -46,14 +45,13 @@ class RunnerTests: XCTestCase {
     plugin.handle(
       call,
       result: { (result: Any?) -> Void in
-        XCTAssertNotNil(result)
-        let canLaunch = result! as? Bool
-        XCTAssertNotNil(canLaunch)
-        XCTAssertTrue(canLaunch!)
+        XCTAssertEqual(result as? Bool, true)
       })
   }
 
-  func testCanLaunchFailureFalse() throws {
+  func testCanLaunchFailureReturnsFalse() throws {
+    let plugin = UrlLauncherPlugin()
+
     let call = FlutterMethodCall(
       methodName: "canLaunch",
       arguments: ["url": "brokenUrl"])
@@ -61,14 +59,13 @@ class RunnerTests: XCTestCase {
     plugin.handle(
       call,
       result: { (result: Any?) -> Void in
-        XCTAssertNotNil(result)
-        let canLaunch = result! as? Bool
-        XCTAssertNotNil(canLaunch)
-        XCTAssertFalse(canLaunch!)
+        XCTAssertEqual(result as? Bool, false)
       })
   }
 
-  func testCanLaunchFailureError() throws {
+  func testCanLaunchMissingArgumentReturnsFlutterError() throws {
+    let plugin = UrlLauncherPlugin()
+
     let call = FlutterMethodCall(
       methodName: "canLaunch",
       arguments: [])
@@ -76,12 +73,14 @@ class RunnerTests: XCTestCase {
     plugin.handle(
       call,
       result: { (result: Any?) -> Void in
-        XCTAssertNotNil(result)
         XCTAssertTrue(result! is FlutterError)
       })
   }
 
-  func testLaunchSuccess() throws {
+  func testLaunchSuccessReturnsTrue() throws {
+    let workspace = StubWorkspace()
+    let pluginWithStubWorkspace = UrlLauncherPlugin(workspace)
+
     let call = FlutterMethodCall(
       methodName: "launch",
       arguments: ["url": "https://flutter.dev"])
@@ -89,13 +88,14 @@ class RunnerTests: XCTestCase {
     pluginWithStubWorkspace.handle(
       call,
       result: { (result: Any?) -> Void in
-        XCTAssertNotNil(result)
-        let launch = result! as? Bool
-        XCTAssertNotNil(launch)
+          XCTAssertEqual(result as? Bool, true)
       })
   }
 
-  func testLaunchFailureError() throws {
+  func testLaunchMissingArgumentReturnsFlutterError() throws {
+    let workspace = StubWorkspace()
+    let pluginWithStubWorkspace = UrlLauncherPlugin(workspace)
+
     let call = FlutterMethodCall(
       methodName: "canLaunch",
       arguments: [])
@@ -103,9 +103,7 @@ class RunnerTests: XCTestCase {
     pluginWithStubWorkspace.handle(
       call,
       result: { (result: Any?) -> Void in
-        XCTAssertNotNil(result)
         XCTAssertTrue(result! is FlutterError)
       })
   }
-
 }

--- a/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
+++ b/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
@@ -100,7 +100,7 @@ class RunnerTests: XCTestCase {
 
     let call = FlutterMethodCall(
       methodName: "launch",
-      arguments: ["url": "example://flutter.dev"])
+      arguments: ["url": "schemethatdoesnotexist://flutter.dev"])
 
     pluginWithStubWorkspace.handle(
       call,

--- a/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
+++ b/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
@@ -22,20 +22,6 @@ class StubWorkspace: SystemURLHandler {
 
 class RunnerTests: XCTestCase {
 
-  func testNoHandlerReturnsFlutterMethodNotImplemented() throws {
-    let plugin = UrlLauncherPlugin()
-
-    let call = FlutterMethodCall(
-      methodName: "noHandler",
-      arguments: ["url": "https://flutter.dev"])
-
-    plugin.handle(
-      call,
-      result: { (result: Any?) -> Void in
-        XCTAssertEqual(result as? NSObject, FlutterMethodNotImplemented)
-      })
-  }
-
   func testCanLaunchSuccessReturnsTrue() throws {
     let plugin = UrlLauncherPlugin()
 
@@ -47,6 +33,20 @@ class RunnerTests: XCTestCase {
       call,
       result: { (result: Any?) -> Void in
         XCTAssertEqual(result as? Bool, true)
+      })
+  }
+
+  func testCanLaunchNoAppIsAbleToOpenUrlReturnsFalse() throws {
+    let plugin = UrlLauncherPlugin()
+
+    let call = FlutterMethodCall(
+      methodName: "canLaunch",
+      arguments: ["url": "example://flutter.dev"])
+
+    plugin.handle(
+      call,
+      result: { (result: Any?) -> Void in
+        XCTAssertEqual(result as? Bool, false)
       })
   }
 
@@ -93,12 +93,28 @@ class RunnerTests: XCTestCase {
       })
   }
 
+  func testLaunchNoAppIsAbleToOpenUrlReturnsFalse() throws {
+    let workspace = StubWorkspace()
+    workspace.isSuccessful = false
+    let pluginWithStubWorkspace = UrlLauncherPlugin(workspace)
+
+    let call = FlutterMethodCall(
+      methodName: "launch",
+      arguments: ["url": "example://flutter.dev"])
+
+    pluginWithStubWorkspace.handle(
+      call,
+      result: { (result: Any?) -> Void in
+        XCTAssertEqual(result as? Bool, false)
+      })
+  }
+
   func testLaunchMissingArgumentReturnsFlutterError() throws {
     let workspace = StubWorkspace()
     let pluginWithStubWorkspace = UrlLauncherPlugin(workspace)
 
     let call = FlutterMethodCall(
-      methodName: "canLaunch",
+      methodName: "launch",
       arguments: [])
 
     pluginWithStubWorkspace.handle(

--- a/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
+++ b/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
@@ -6,7 +6,7 @@ import FlutterMacOS
 import XCTest
 import url_launcher_macos
 
-/// A stub for testing the open method.
+/// A stub to simulate the system Url handler.
 class StubWorkspace: SystemURLHandler {
 
   var isSuccessful = true

--- a/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
+++ b/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
@@ -50,7 +50,7 @@ class RunnerTests: XCTestCase {
       })
   }
 
-  func testCanLaunchFailureReturnsFalse() throws {
+  func testCanLaunchInvalidUrlReturnsFalse() throws {
     let plugin = UrlLauncherPlugin()
 
     let call = FlutterMethodCall(

--- a/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
+++ b/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
@@ -8,7 +8,7 @@ import url_launcher_macos
 
 class StubWorkspace: URLLauncher {
   var isSuccessful = true
-    var url = URL.init(string: "https://flutter.dev")
+  var url = URL.init(string: "https://flutter.dev")
 
   func open(_ url: URL) -> Bool {
     return isSuccessful
@@ -23,19 +23,22 @@ class StubWorkspace: URLLauncher {
 class RunnerTests: XCTestCase {
 
   var workspace: StubWorkspace! = nil
+  var pluginWithStubWorkspace: UrlLauncherPlugin! = nil
   var plugin: UrlLauncherPlugin! = nil
 
   override func setUp() {
     workspace = StubWorkspace()
+    pluginWithStubWorkspace = UrlLauncherPlugin(workspace)
     plugin = UrlLauncherPlugin()
   }
 
   override func tearDown() {
     workspace = nil
+    pluginWithStubWorkspace = nil
     plugin = nil
   }
 
-  func testCanLaunch() throws {
+  func testCanLaunchSuccessTrue() throws {
     let call = FlutterMethodCall(
       methodName: "canLaunch",
       arguments: ["url": "https://flutter.dev"])
@@ -43,21 +46,66 @@ class RunnerTests: XCTestCase {
     plugin.handle(
       call,
       result: { (result: Any?) -> Void in
-        let canLaunch: Bool? = result as? Bool
-        XCTAssertTrue(canLaunch == true)
-      }, with: workspace)
+        XCTAssertNotNil(result)
+        let canLuanch = result! as? Bool
+        XCTAssertNotNil(canLuanch)
+        XCTAssertTrue(canLuanch!)
+      })
   }
 
-  func testLaunch() throws {
+  func testCanLaunchFailureFalse() throws {
     let call = FlutterMethodCall(
-      methodName: "launch",
-      arguments: ["url": "https://flutter.dev"])
+      methodName: "canLaunch",
+      arguments: ["url": "brokenUrl"])
 
     plugin.handle(
       call,
       result: { (result: Any?) -> Void in
-        XCTAssertTrue(result as? Bool == true)
-      }, with: workspace)
+        XCTAssertNotNil(result)
+        let canLuanch = result! as? Bool
+        XCTAssertNotNil(canLuanch)
+        XCTAssertFalse(canLuanch!)
+      })
+  }
+
+  func testCanLaunchFailureError() throws {
+    let call = FlutterMethodCall(
+      methodName: "canLaunch",
+      arguments: [])
+
+    plugin.handle(
+      call,
+      result: { (result: Any?) -> Void in
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result! is FlutterError)
+      })
+  }
+
+  func testLaunchSuccess() throws {
+    let call = FlutterMethodCall(
+      methodName: "launch",
+      arguments: ["url": "https://flutter.dev"])
+
+    pluginWithStubWorkspace.handle(
+      call,
+      result: { (result: Any?) -> Void in
+          XCTAssertNotNil(result)
+          let launch = result! as? Bool
+          XCTAssertNotNil(launch)
+      })
+  }
+
+  func testLaunchFailureError() throws {
+    let call = FlutterMethodCall(
+      methodName: "canLaunch",
+      arguments: [])
+
+    pluginWithStubWorkspace.handle(
+      call,
+      result: { (result: Any?) -> Void in
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result! is FlutterError)
+      })
   }
 
 }

--- a/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
+++ b/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
@@ -16,7 +16,7 @@ class StubWorkspace: SystemURLHandler {
   }
 
   func urlForApplication(toOpen: URL) -> URL? {
-      return toOpen
+    return toOpen
   }
 }
 
@@ -89,7 +89,7 @@ class RunnerTests: XCTestCase {
     pluginWithStubWorkspace.handle(
       call,
       result: { (result: Any?) -> Void in
-          XCTAssertEqual(result as? Bool, true)
+        XCTAssertEqual(result as? Bool, true)
       })
   }
 

--- a/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
+++ b/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
@@ -6,6 +6,7 @@ import FlutterMacOS
 import XCTest
 import url_launcher_macos
 
+/// A stub for testing the open method.
 class StubWorkspace: SystemURLHandler {
 
   var isSuccessful = true

--- a/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
+++ b/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
@@ -74,7 +74,7 @@ class RunnerTests: XCTestCase {
     plugin.handle(
       call,
       result: { (result: Any?) -> Void in
-        XCTAssertTrue(result! is FlutterError)
+        XCTAssertTrue(result is FlutterError)
       })
   }
 
@@ -104,7 +104,7 @@ class RunnerTests: XCTestCase {
     pluginWithStubWorkspace.handle(
       call,
       result: { (result: Any?) -> Void in
-        XCTAssertTrue(result! is FlutterError)
+        XCTAssertTrue(result is FlutterError)
       })
   }
 }

--- a/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
+++ b/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
@@ -23,6 +23,7 @@ class StubWorkspace: SystemURLHandler {
 class RunnerTests: XCTestCase {
 
   func testCanLaunchSuccessReturnsTrue() throws {
+    let expectation = XCTestExpectation(description: "Check if the URL can be launched")
     let plugin = UrlLauncherPlugin()
 
     let call = FlutterMethodCall(
@@ -33,10 +34,14 @@ class RunnerTests: XCTestCase {
       call,
       result: { (result: Any?) -> Void in
         XCTAssertEqual(result as? Bool, true)
+        expectation.fulfill()
       })
+
+    wait(for: [expectation], timeout: 10.0)
   }
 
   func testCanLaunchNoAppIsAbleToOpenUrlReturnsFalse() throws {
+    let expectation = XCTestExpectation(description: "Check if the URL can be launched")
     let plugin = UrlLauncherPlugin()
 
     let call = FlutterMethodCall(
@@ -47,10 +52,14 @@ class RunnerTests: XCTestCase {
       call,
       result: { (result: Any?) -> Void in
         XCTAssertEqual(result as? Bool, false)
+        expectation.fulfill()
       })
+
+    wait(for: [expectation], timeout: 10.0)
   }
 
   func testCanLaunchInvalidUrlReturnsFalse() throws {
+    let expectation = XCTestExpectation(description: "Check if the URL can be launched")
     let plugin = UrlLauncherPlugin()
 
     let call = FlutterMethodCall(
@@ -61,10 +70,14 @@ class RunnerTests: XCTestCase {
       call,
       result: { (result: Any?) -> Void in
         XCTAssertEqual(result as? Bool, false)
+        expectation.fulfill()
       })
+
+    wait(for: [expectation], timeout: 10.0)
   }
 
   func testCanLaunchMissingArgumentReturnsFlutterError() throws {
+    let expectation = XCTestExpectation(description: "Check if the URL can be launched")
     let plugin = UrlLauncherPlugin()
 
     let call = FlutterMethodCall(
@@ -75,10 +88,14 @@ class RunnerTests: XCTestCase {
       call,
       result: { (result: Any?) -> Void in
         XCTAssertTrue(result is FlutterError)
+        expectation.fulfill()
       })
+
+    wait(for: [expectation], timeout: 10.0)
   }
 
   func testLaunchSuccessReturnsTrue() throws {
+    let expectation = XCTestExpectation(description: "Try to open the URL")
     let workspace = StubWorkspace()
     let pluginWithStubWorkspace = UrlLauncherPlugin(workspace)
 
@@ -90,10 +107,14 @@ class RunnerTests: XCTestCase {
       call,
       result: { (result: Any?) -> Void in
         XCTAssertEqual(result as? Bool, true)
+        expectation.fulfill()
       })
+
+    wait(for: [expectation], timeout: 10.0)
   }
 
   func testLaunchNoAppIsAbleToOpenUrlReturnsFalse() throws {
+    let expectation = XCTestExpectation(description: "Try to open the URL")
     let workspace = StubWorkspace()
     workspace.isSuccessful = false
     let pluginWithStubWorkspace = UrlLauncherPlugin(workspace)
@@ -106,10 +127,14 @@ class RunnerTests: XCTestCase {
       call,
       result: { (result: Any?) -> Void in
         XCTAssertEqual(result as? Bool, false)
+        expectation.fulfill()
       })
+
+    wait(for: [expectation], timeout: 10.0)
   }
 
   func testLaunchMissingArgumentReturnsFlutterError() throws {
+    let expectation = XCTestExpectation(description: "Try to open the URL")
     let workspace = StubWorkspace()
     let pluginWithStubWorkspace = UrlLauncherPlugin(workspace)
 
@@ -122,5 +147,7 @@ class RunnerTests: XCTestCase {
       result: { (result: Any?) -> Void in
         XCTAssertTrue(result is FlutterError)
       })
+
+    wait(for: [expectation], timeout: 10.0)
   }
 }

--- a/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
+++ b/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
@@ -6,19 +6,60 @@ import FlutterMacOS
 import XCTest
 import url_launcher_macos
 
+class StubWorkspace: URLLauncher {
+  var isSuccessful = true
+    var url = URL.init(string: "https://flutter.dev")
+
+  func open(_ url: URL) -> Bool {
+    return isSuccessful
+  }
+
+  func urlForApplication(toOpen: URL) -> URL? {
+    return url
+  }
+
+}
+
 class RunnerTests: XCTestCase {
+
+  var workspace: StubWorkspace! = nil
+  var plugin: UrlLauncherPlugin! = nil
+
+  override func setUp() {
+    workspace = StubWorkspace()
+    plugin = UrlLauncherPlugin()
+    plugin.workspace = workspace
+  }
+
+  override func tearDown() {
+    workspace = nil
+    plugin = nil
+  }
+
   func testCanLaunch() throws {
-    let plugin = UrlLauncherPlugin()
     let call = FlutterMethodCall(
       methodName: "canLaunch",
       arguments: ["url": "https://flutter.dev"])
-    var canLaunch: Bool?
+
     plugin.handle(
       call,
       result: { (result: Any?) -> Void in
-        canLaunch = result as? Bool
+        XCTAssertTrue(result as? Bool == true)
       })
 
-    XCTAssertTrue(canLaunch == true)
+    
   }
+
+  func testLaunch() throws {
+    let call = FlutterMethodCall(
+      methodName: "launch",
+      arguments: ["url": "https://flutter.dev"])
+
+    plugin.handle(
+      call,
+      result: { (result: Any?) -> Void in
+        XCTAssertTrue(result as? Bool == true)
+      })
+  }
+
 }

--- a/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
+++ b/packages/url_launcher/url_launcher_macos/example/macos/RunnerTests/RunnerTests.swift
@@ -28,7 +28,6 @@ class RunnerTests: XCTestCase {
   override func setUp() {
     workspace = StubWorkspace()
     plugin = UrlLauncherPlugin()
-    plugin.workspace = workspace
   }
 
   override func tearDown() {
@@ -44,10 +43,9 @@ class RunnerTests: XCTestCase {
     plugin.handle(
       call,
       result: { (result: Any?) -> Void in
-        XCTAssertTrue(result as? Bool == true)
-      })
-
-    
+        let canLaunch: Bool? = result as? Bool
+        XCTAssertTrue(canLaunch == true)
+      }, with: workspace)
   }
 
   func testLaunch() throws {
@@ -59,7 +57,7 @@ class RunnerTests: XCTestCase {
       call,
       result: { (result: Any?) -> Void in
         XCTAssertTrue(result as? Bool == true)
-      })
+      }, with: workspace)
   }
 
 }

--- a/packages/url_launcher/url_launcher_macos/macos/Classes/UrlLauncherPlugin.swift
+++ b/packages/url_launcher/url_launcher_macos/macos/Classes/UrlLauncherPlugin.swift
@@ -14,7 +14,7 @@ extension NSWorkspace : URLLauncher {}
 
 public class UrlLauncherPlugin: NSObject, FlutterPlugin {
 
-  public var workspace: URLLauncher = NSWorkspace.shared
+  private var workspace: URLLauncher = NSWorkspace.shared
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(
@@ -22,6 +22,13 @@ public class UrlLauncherPlugin: NSObject, FlutterPlugin {
       binaryMessenger: registrar.messenger)
     let instance = UrlLauncherPlugin()
     registrar.addMethodCallDelegate(instance, channel: channel)
+  }
+
+  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult, with workspace: URLLauncher) {
+    self.workspace = workspace
+    self.handle(call, result: { (resultIn: Any?) -> Void in
+        result(resultIn)
+    })
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {

--- a/packages/url_launcher/url_launcher_macos/macos/Classes/UrlLauncherPlugin.swift
+++ b/packages/url_launcher/url_launcher_macos/macos/Classes/UrlLauncherPlugin.swift
@@ -5,7 +5,17 @@
 import FlutterMacOS
 import Foundation
 
+public protocol URLLauncher {
+  func open(_ url: URL) -> Bool
+  func urlForApplication(toOpen: URL) -> URL?
+}
+
+extension NSWorkspace : URLLauncher {}
+
 public class UrlLauncherPlugin: NSObject, FlutterPlugin {
+
+  public var workspace: URLLauncher = NSWorkspace.shared
+
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(
       name: "plugins.flutter.io/url_launcher",
@@ -24,7 +34,7 @@ public class UrlLauncherPlugin: NSObject, FlutterPlugin {
         result(invalidURLError(urlString))
         return
       }
-      result(NSWorkspace.shared.urlForApplication(toOpen: url) != nil)
+      result(workspace.urlForApplication(toOpen: url) != nil)
     case "launch":
       guard let unwrappedURLString = urlString,
         let url = URL.init(string: unwrappedURLString)
@@ -32,7 +42,7 @@ public class UrlLauncherPlugin: NSObject, FlutterPlugin {
         result(invalidURLError(urlString))
         return
       }
-      result(NSWorkspace.shared.open(url))
+      result(workspace.open(url))
     default:
       result(FlutterMethodNotImplemented)
     }

--- a/packages/url_launcher/url_launcher_macos/macos/Classes/UrlLauncherPlugin.swift
+++ b/packages/url_launcher/url_launcher_macos/macos/Classes/UrlLauncherPlugin.swift
@@ -5,18 +5,18 @@
 import FlutterMacOS
 import Foundation
 
-public protocol URLLauncher {
+public protocol SystemURLHandler {
   func open(_ url: URL) -> Bool
   func urlForApplication(toOpen: URL) -> URL?
 }
 
-extension NSWorkspace: URLLauncher {}
+extension NSWorkspace: SystemURLHandler {}
 
 public class UrlLauncherPlugin: NSObject, FlutterPlugin {
 
   private var workspace: URLLauncher
 
-  public init(_ workspace: URLLauncher = NSWorkspace.shared) {
+  public init(_ workspace: SystemURLHandler = NSWorkspace.shared) {
     self.workspace = workspace
   }
 

--- a/packages/url_launcher/url_launcher_macos/macos/Classes/UrlLauncherPlugin.swift
+++ b/packages/url_launcher/url_launcher_macos/macos/Classes/UrlLauncherPlugin.swift
@@ -10,7 +10,7 @@ public protocol URLLauncher {
   func urlForApplication(toOpen: URL) -> URL?
 }
 
-extension NSWorkspace : URLLauncher {}
+extension NSWorkspace: URLLauncher {}
 
 public class UrlLauncherPlugin: NSObject, FlutterPlugin {
 

--- a/packages/url_launcher/url_launcher_macos/macos/Classes/UrlLauncherPlugin.swift
+++ b/packages/url_launcher/url_launcher_macos/macos/Classes/UrlLauncherPlugin.swift
@@ -9,9 +9,18 @@ import Foundation
 public protocol SystemURLHandler {
 
   /// Opens the location at the specified URL.
+  ///
+  /// - Parameters:
+  ///   - url: A URL specifying the location to open.
+  /// - Returns: true if the location was successfully opened; otherwise, false.
   func open(_ url: URL) -> Bool
 
   /// Returns the URL to the default app that would be opened.
+  ///
+  /// - Parameters:
+  ///   - toOpen: The URL of the file to open.
+  /// - Returns: The URL of the default app that would open the specified url.
+  ///   Returns nil if no app is able to open the URL, or if the file URL does not exist.
   func urlForApplication(toOpen: URL) -> URL?
 }
 

--- a/packages/url_launcher/url_launcher_macos/macos/Classes/UrlLauncherPlugin.swift
+++ b/packages/url_launcher/url_launcher_macos/macos/Classes/UrlLauncherPlugin.swift
@@ -14,7 +14,11 @@ extension NSWorkspace : URLLauncher {}
 
 public class UrlLauncherPlugin: NSObject, FlutterPlugin {
 
-  private var workspace: URLLauncher = NSWorkspace.shared
+  private var workspace: URLLauncher
+
+  public init(_ workspace: URLLauncher = NSWorkspace.shared) {
+    self.workspace = workspace
+  }
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(
@@ -22,13 +26,6 @@ public class UrlLauncherPlugin: NSObject, FlutterPlugin {
       binaryMessenger: registrar.messenger)
     let instance = UrlLauncherPlugin()
     registrar.addMethodCallDelegate(instance, channel: channel)
-  }
-
-  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult, with workspace: URLLauncher) {
-    self.workspace = workspace
-    self.handle(call, result: { (resultIn: Any?) -> Void in
-        result(resultIn)
-    })
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {

--- a/packages/url_launcher/url_launcher_macos/macos/Classes/UrlLauncherPlugin.swift
+++ b/packages/url_launcher/url_launcher_macos/macos/Classes/UrlLauncherPlugin.swift
@@ -5,8 +5,13 @@
 import FlutterMacOS
 import Foundation
 
+/// A handler that can launch other apps, check if any app is able to open the URL.
 public protocol SystemURLHandler {
+
+  /// Opens the location at the specified URL.
   func open(_ url: URL) -> Bool
+
+  /// Returns the URL to the default app that would be opened.
   func urlForApplication(toOpen: URL) -> URL?
 }
 
@@ -14,7 +19,7 @@ extension NSWorkspace: SystemURLHandler {}
 
 public class UrlLauncherPlugin: NSObject, FlutterPlugin {
 
-  private var workspace: URLLauncher
+  private var workspace: SystemURLHandler
 
   public init(_ workspace: SystemURLHandler = NSWorkspace.shared) {
     self.workspace = workspace


### PR DESCRIPTION
Add unit tests for url_launcher canLaunch and launch methods on mac with success and failure results.

Fixes #[92969]

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[92969]: https://github.com/flutter/flutter/issues/92969
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
