### PR TITLE
[url_launcher_linux] add file scheme support for canLaunch

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -41,6 +41,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo ap
 RUN echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | sudo tee /etc/apt/sources.list.d/google-chrome.list
 RUN apt-get update && apt-get install -y --no-install-recommends google-chrome-stable
 
-# Make Chrome the default so http: has a handler for url_launcher tests.
+# Make Chrome the default so http: and file: has a handler for url_launcher tests.
 RUN apt-get install -y xdg-utils
 RUN xdg-settings set default-web-browser google-chrome.desktop
+RUN xdg-mime default google-chrome.desktop inode/directory

--- a/packages/url_launcher/url_launcher_linux/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3
+
+* Fix canLaunch detection for `file` scheme
+
 ## 2.0.2
 
 * Replaced reference to `shared_preferences` plugin with the `url_launcher` in the README.

--- a/packages/url_launcher/url_launcher_linux/linux/test/url_launcher_linux_test.cc
+++ b/packages/url_launcher/url_launcher_linux/linux/test/url_launcher_linux_test.cc
@@ -39,6 +39,31 @@ TEST(UrlLauncherPlugin, CanLaunchFailureUnhandled) {
                              expected));
 }
 
+TEST(UrlLauncherPlugin, CanLaunchFileSuccess) {
+  g_autoptr(FlValue) args = fl_value_new_map();
+  fl_value_set_string_take(args, "url", fl_value_new_string("file:/"));
+  FlMethodResponse* response = can_launch(nullptr, args);
+  ASSERT_NE(response, nullptr);
+  ASSERT_TRUE(FL_IS_METHOD_SUCCESS_RESPONSE(response));
+  g_autoptr(FlValue) expected = fl_value_new_bool(true);
+  EXPECT_TRUE(fl_value_equal(fl_method_success_response_get_result(
+                                 FL_METHOD_SUCCESS_RESPONSE(response)),
+                             expected));
+}
+
+TEST(UrlLauncherPlugin, CanLaunchFailureInvalidFileExtension) {
+  g_autoptr(FlValue) args = fl_value_new_map();
+  fl_value_set_string_take(
+      args, "url", fl_value_new_string("file:///madeup.madeupextension"));
+  FlMethodResponse* response = can_launch(nullptr, args);
+  ASSERT_NE(response, nullptr);
+  ASSERT_TRUE(FL_IS_METHOD_SUCCESS_RESPONSE(response));
+  g_autoptr(FlValue) expected = fl_value_new_bool(false);
+  EXPECT_TRUE(fl_value_equal(fl_method_success_response_get_result(
+                                 FL_METHOD_SUCCESS_RESPONSE(response)),
+                             expected));
+}
+
 // For consistency with the established mobile implementations,
 // an invalid URL should return false, not an error.
 TEST(UrlLauncherPlugin, CanLaunchFailureInvalidUrl) {

--- a/packages/url_launcher/url_launcher_linux/linux/url_launcher_plugin.cc
+++ b/packages/url_launcher/url_launcher_linux/linux/url_launcher_plugin.cc
@@ -45,6 +45,21 @@ static gchar* get_url(FlValue* args, GError** error) {
   return g_strdup(fl_value_get_string(url_value));
 }
 
+// Called to check if URL with file scheme can be launched.
+static gboolean can_launch_url_with_file_scheme(FlUrlLauncherPlugin* self,
+                                                const gchar* url) {
+  g_autoptr(GError) error = nullptr;
+  GFile* file = g_file_new_for_uri(url);
+  GAppInfo* app_info = g_file_query_default_handler(file, NULL, &error);
+  g_object_unref(file);
+  gboolean is_launchable = FALSE;
+  if (app_info != nullptr) {
+    is_launchable = TRUE;
+    g_object_unref(app_info);
+  }
+  return is_launchable;
+}
+
 // Called to check if a URL can be launched.
 FlMethodResponse* can_launch(FlUrlLauncherPlugin* self, FlValue* args) {
   g_autoptr(GError) error = nullptr;
@@ -60,6 +75,10 @@ FlMethodResponse* can_launch(FlUrlLauncherPlugin* self, FlValue* args) {
     g_autoptr(GAppInfo) app_info =
         g_app_info_get_default_for_uri_scheme(scheme);
     is_launchable = app_info != nullptr;
+
+    if (!is_launchable) {
+      is_launchable = can_launch_url_with_file_scheme(self, url);
+    }
   }
 
   g_autoptr(FlValue) result = fl_value_new_bool(is_launchable);

--- a/packages/url_launcher/url_launcher_linux/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_linux
 description: Linux implementation of the url_launcher plugin.
 repository: https://github.com/flutter/plugins/tree/master/packages/url_launcher/url_launcher_linux
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 2.0.2
+version: 2.0.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Fixes `canLaunch` implementation for `file` scheme. 
`canLaunch` incorrectly returned a `false` response to launchable file scheme URLs.
Fix uses `g_content_type_guess` to guess `content_type` from the filepath and `g_app_info_get_default_for_type` to detect if any application is associated for found `content_type`.

*List which issues are fixed by this PR. You must list at least one issue.*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Note that unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I [updated pubspec.yaml](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates) with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
